### PR TITLE
pkp/pkp-lib#788 Implement new RevealMore handler for viewing reviews

### DIFF
--- a/js/controllers/RevealMoreHandler.js
+++ b/js/controllers/RevealMoreHandler.js
@@ -1,0 +1,55 @@
+/**
+ * @file js/controllers/RevealMoreHandler.js
+ *
+ * Copyright (c) 2014-2016 Simon Fraser University Library
+ * Copyright (c) 2000-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class RevealMoreHandler
+ * @ingroup js_controllers
+ *
+ * @brief A basic handler for the reveal more UI pattern
+ */
+(function($) {
+
+
+	/**
+	 * @constructor
+	 *
+	 * @extends $.pkp.classes.Handler
+	 *
+	 * @param {jQueryObject} $widgetWrapper An HTML element that contains the
+	 *   widget.
+	 * @param {Object} options Handler options.
+	 */
+	$.pkp.controllers.RevealMoreHandler = function($widgetWrapper, options) {
+		this.parent($widgetWrapper, options);
+
+		if ($widgetWrapper.outerHeight() > options.height) {
+			$widgetWrapper.addClass('isHidden').css('max-height', options.height + 'px');
+			$('.revealMoreButton', $widgetWrapper).click(
+					this.callbackWrapper(this.revealMore));
+		}
+	};
+	$.pkp.classes.Helper.inherits(
+			$.pkp.controllers.RevealMoreHandler, $.pkp.classes.Handler);
+
+
+	//
+	// Public methods
+	//
+	/**
+	 * Event handler that is called when the button to reveal more is clicked
+	 *
+	 * @param {HTMLElement} revealMoreButton The button that is clicked to toggle extras.
+	 * @param {Event} event The triggering event.
+	 */
+	$.pkp.controllers.RevealMoreHandler.prototype.revealMore =
+			function(revealMoreButton, event) {
+		this.getHtmlElement().removeClass('isHidden').css('max-height', 'auto');
+		event.preventDefault();
+		event.stopPropagation();
+	};
+
+/** @param {jQuery} $ jQuery closure. */
+}(jQuery));

--- a/styles/controllers/index.less
+++ b/styles/controllers/index.less
@@ -18,5 +18,6 @@
 @import "lib/pkp/styles/controllers/notification.less";
 @import "lib/pkp/styles/controllers/plupload.less";
 @import "lib/pkp/styles/controllers/rangeSlider.less";
+@import "lib/pkp/styles/controllers/revealMore.less";
 @import "lib/pkp/styles/controllers/tab.less";
 @import "lib/pkp/styles/controllers/statistics.less";

--- a/styles/controllers/revealMore.less
+++ b/styles/controllers/revealMore.less
@@ -1,0 +1,58 @@
+/**
+ * @file styles/controllers/revealMore.less
+ *
+ * Copyright (c) 2014-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @ingroup pkp_controllers_revealMore
+ *
+ * @brief Reveal more widget styles
+ */
+
+.pkp_controllers_revealMore {
+	position: relative;
+
+	.reveal_more_wrapper {
+		display: none;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		height: @double;
+		width: 100%;
+		background: #fff;
+		border-top: @bg-border;
+		text-align: center;
+
+		button {
+			border: none;
+			background: #fff;
+			color: @primary-lift;
+			font-size: @font-sml;
+			line-height: @line-sml;
+			font-weight: @bold;
+
+			&:hover,
+			&:focus {
+				color: @primary;
+			}
+
+			&:before {
+				&:extend(.pkp_caret);
+				&:extend(.pkp_caret_down);
+				position: relative;
+				top: 1px;
+				margin-right: 0.5em;
+			}
+		}
+	}
+
+	&.isHidden {
+		overflow-y: hidden;
+
+		.reveal_more_wrapper {
+			display: block;
+		}
+	}
+}

--- a/templates/controllers/grid/users/reviewer/readReview.tpl
+++ b/templates/controllers/grid/users/reviewer/readReview.tpl
@@ -35,10 +35,7 @@
 				{include file="reviewer/review/reviewFormResponse.tpl"}
 			{elseif $reviewerComment}
 				<h3>{translate key="editor.review.reviewerComments"}</h3>
-				{assign var="contents" value=$reviewerComment->getComments()}
-				<span id="reviewContents">
-					{$contents|nl2br|strip_unsafe_html}
-				</span>
+				{include file="controllers/revealMore.tpl" content=$reviewerComment->getComments()|nl2br|strip_unsafe_html}
 			{/if}
 			{if $reviewAssignment->getRecommendation()}
 				<h3>{translate key="submission.recommendation" recommendation=$reviewAssignment->getLocalizedRecommendation()}</h3>

--- a/templates/controllers/revealMore.tpl
+++ b/templates/controllers/revealMore.tpl
@@ -1,0 +1,35 @@
+{**
+ * controllers/revealMore.tpl
+ *
+ * Copyright (c) 2014-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Basic markup for the reveal more widget.
+ *
+ * @uses $content string Content to handle
+ * @uses $height int Max height of truncated content (pixels). Default: 192
+ *}
+{assign var=id value=10|uniqid}
+{if !$height}
+	{assign var=height value=192}
+{/if}
+<script>
+	// Initialise JS handler.
+	$(function() {ldelim}
+		$('#revealMore-{$id}').pkpHandler(
+			'$.pkp.controllers.RevealMoreHandler',
+			{ldelim}
+				height: {$height}
+			{rdelim}
+		);
+	{rdelim});
+</script>
+<div id="revealMore-{$id}" class="pkp_controllers_revealMore">
+	{$content}
+	<div class="reveal_more_wrapper">
+		<button href="#" class="revealMoreButton">
+			{translate key="common.readMore"}
+		</button>
+	</div>
+</div>


### PR DESCRIPTION
Hi Bozana, this should take care of reading some/all of the reviews.

In addition to this PR, you'll also need to add the new `/lib/pkp/js/controllers/RevealMoreHandler.js` file to the `templates/common/mindifiedScripts.tpl` file for both OJS and OMP.

I thought it might be easier for you to just do that in your repos to add to the PR, rather than me issuing a separate PR for the one-line change.
